### PR TITLE
`ref` property is unnecessary and should be removed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ function deepPluckRef(obj, findProps) {
 	if(typeof findProps.forEach !== 'function') return undefined;
 	var results = [];
 	function recurse(o) {
-		var ref = {ref: o};
+		var ref = o;
 		Object.keys(o).forEach(function keysForEachCb(m) {
 			~findProps.indexOf(m) && !~results.indexOf(ref) && results.push(ref);
 			typeof o[m] === 'object' && recurse(o[m]);

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,8 @@ describe('Module tests', function describeCb() {
 		};
 		var results = deepPluckRef(obj, ['value']);
 		results.length.should.equal(2);
+		const valuesPresent = results.every(r => (typeof r.value).should.equal('string'));
+		valuesPresent.should.equal(true);
 		done();
 	});
 


### PR DESCRIPTION
The reference should be returned without being attached to a `ref` property. 